### PR TITLE
docker compose do banco local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# Banco MongoDB para ambiente de desenvolvimento local
+# Para rodar, use o comando: docker-compose up -d
+# Para parar, use: docker-compose down
+services:
+  mongodb:
+    image: mongo:latest
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_DATABASE: test
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
p/ facilitar desenvolvimento local: modelo de docker-compose. Não recomendo essa exposição de keys em ambiente de prod.